### PR TITLE
fix(post): only style paragraphs with next images in them

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -8,7 +8,7 @@ export default function Document() {
         <link
           rel="preconnect"
           href="https://fonts.gstatic.com"
-          crossOrigin
+          crossOrigin="true"
         ></link>
         <link
           href="https://fonts.googleapis.com/css2?family=Lora&display=swap"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -84,12 +84,12 @@ footer {
 .post__container {
 }
 
-/* this is very specific to capturing images that are approximately 1281x999 */
-.post__container p {
+/* this is very specific to capturing images that are approximately the same size*/
+.post__container p:has(> span > img) {
   display: block;
   position: relative;
   height: 100vmin;
-  aspect-ratio: 1.28228228;
+  aspect-ratio: 1.28228228; /* 1281x999 */
 }
 
 /* THEME COLOR */


### PR DESCRIPTION
without this clarification, https://www.makeapullre.quest/early was also styling all `p` tags with a `100vmin` value, making for some dramatic but not ideal scrolling